### PR TITLE
DEV: use install_requires instead of setup_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,5 @@ setup(
     keywords=['outlier', 'anomaly', 'detection', 'machine', 'learning', 'probability'],
     classifiers=[],
     license='Apache License, Version 2.0',
-    setup_requires=['numpy']
+    install_requires=['numpy']
 )


### PR DESCRIPTION
`pip install PyNomaly` currently doesn't install numpy.