### PR TITLE
Feature/release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,24 @@
+on:
+  push:
+    branches:
+      - main # release branch (default)
+
+permissions:
+  contents: write
+  pull-requests: write
+
+name: release-please
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          # this assumes that you have created a personal access token
+          # (PAT) and configured it as a GitHub action secret named
+          # `RELEASE_PLEASE_PERSONAL_ACCESS_TOKEN` (this secret name is not important).
+          token: ${{ secrets.RELEASE_PLEASE_PERSONAL_ACCESS_TOKEN }}
+          # this is a built-in strategy in release-please, see "Action Inputs"
+          # for more options
+          release-type: simple

--- a/readme.md
+++ b/readme.md
@@ -401,10 +401,15 @@ any changes to a branch which corresponds to an open issue. Hot fixes
 and bug fixes can be represented by branches with the prefix `fix/` versus 
 `feature/` for new capabilities or code improvements. Pull requests will 
 then be made from these branches into the repository's `dev` branch 
-prior to being pulled into `main`. Pull requests which are works in 
-progress or ready for merging should be indicated by their respective 
-prefixes ([WIP] and [MRG]). Pull requests with the [MRG] prefix will be 
-reviewed prior to being pulled into the `main` branch. 
+prior to being pulled into `main`. 
+
+### Commit Messages and Releases
+
+**Your commit messages are important** - here's why. 
+
+PyNomaly leverages [release-please](https://github.com/googleapis/release-please-action) to help automate the release process using the [Conventional Commits](https://www.conventionalcommits.org/) specification. When pull requests are opened to the `main` branch, release-please will collate the git commit messages and prepare an organized changelog and release notes. This process can be completed because of the Conventional Commits specification. 
+
+Conventional Commits provides an easy set of rules for creating an explicit commit history; which makes it easier to write automated tools on top of. This convention dovetails with SemVer, by describing the features, fixes, and breaking changes made in commit messages. You can check out examples [here](https://www.conventionalcommits.org/en/v1.0.0/#examples). Make a best effort to use the specification when contributing to Infactory code as it dramatically eases the documentation around releases and their features, breaking changes, bug fixes and documentation updates. 
 
 ### Tests
 When contributing, please ensure to run unit tests and add additional tests as 


### PR DESCRIPTION
@IroNEDR opening this pull request to review the setup of the [release-please](https://github.com/marketplace/actions/release-please-action) functionality as discussed in issue #61. 

The workflow can only be fully tested once these code changes are integrated into the `main` branch as release-please is setup in `.github/workflows/release-please` to only draft releases in that branch, but I would like you to review the changes in the contribution guidelines and the setup for awareness and clarity. 

