### PR TITLE
add python 3.13 test to workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ PyNomaly/loop_dev.py
 *.pyc
 *.coverage.*
 .coveragerc
+.pypirc
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ All notable changes to PyNomaly will be documented in this Changelog.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) 
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 0.3.4 
+### Changed 
+- Changed source code as necessary to address a [user-reported issue](https://github.com/vc1492a/PyNomaly/issues/49), corrected in [this commit](https://github.com/vc1492a/PyNomaly/commit/bbdd12a318316ca9c7e0272a5b06909f3fc4f9b0)
+
 ## 0.3.3
 ### Changed
 - The implementation of the progress bar to support use when the number of 


### PR DESCRIPTION
This implements #64 after confirming Python 3.13 is supported by examining the documentation here: https://github.com/actions/setup-python