### PR TITLE
docs: add MkDocs documentation site and expand README

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,19 @@
+name: docs
+
+on:
+  push:
+    branches: [ "main" ]
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pip install mkdocs-material
+      - run: mkdocs gh-deploy --force

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ PyNomaly is a core library of [deepchecks](https://github.com/deepchecks/deepche
 [![Monthly Downloads](https://static.pepy.tech/badge/pynomaly/month)](https://pepy.tech/projects/pynomaly)
 ![Tests](https://github.com/vc1492a/PyNomaly/actions/workflows/tests.yml/badge.svg)
 [![Coverage Status](https://coveralls.io/repos/github/vc1492a/PyNomaly/badge.svg?branch=main)](https://coveralls.io/github/vc1492a/PyNomaly?branch=main)
+[![Documentation](https://img.shields.io/badge/docs-online-blue.svg)](https://vc1492a.github.io/PyNomaly/)
 [![JOSS](http://joss.theoj.org/papers/f4d2cfe680768526da7c1f6a2c103266/status.svg)](http://joss.theoj.org/papers/f4d2cfe680768526da7c1f6a2c103266)
+
+**[Full Documentation](https://vc1492a.github.io/PyNomaly/)** | **[API Reference](https://vc1492a.github.io/PyNomaly/api/)** | **[Examples](https://vc1492a.github.io/PyNomaly/examples/)**
 
 The outlier score of each sample is called the Local Outlier Probability.
 It measures the local deviation of density of a given sample with
@@ -37,6 +40,24 @@ Ludwig-Maximilians University Munich - Institute for Informatics;
 This Python 3 implementation uses Numpy and the formulas outlined in
 [LoOP: Local Outlier Probabilities](http://www.dbs.ifi.lmu.de/Publikationen/Papers/LoOP1649.pdf)
 to calculate the Local Outlier Probability of each sample.
+
+### How It Works
+
+LoOP scores are computed through a pipeline of steps that transform raw distances into a probability:
+
+1. **Nearest neighbor distances**: For each observation, the distances to its *k* nearest neighbors are computed (within its cluster, if cluster labels are provided).
+
+2. **Standard distance**: The root mean square of the neighbor distances for each observation, capturing how far away its neighbors are on average.
+
+3. **Probabilistic distance**: The standard distance scaled by the *extent* parameter (lambda). A higher extent makes the scoring more conservative (fewer points flagged as outliers).
+
+4. **Probabilistic Local Outlier Factor (PLOF)**: The ratio of an observation's probabilistic distance to the expected (mean) probabilistic distance of its neighbors, minus one. A PLOF near zero means the observation's density is similar to its neighbors; a large positive PLOF means it is in a sparser region.
+
+5. **Normalized PLOF (nPLOF)**: A normalization constant derived from the expected squared PLOF values within a cluster, scaled by the extent. This acts as a reference spread so that the final score is comparable across clusters.
+
+6. **Local Outlier Probability (LoOP)**: The Gaussian error function applied to the ratio PLOF / (nPLOF * sqrt(2)), clamped to [0, 1]. The result is directly interpretable as the probability that the observation is an outlier.
+
+For full mathematical detail, see the [original paper](http://www.dbs.ifi.lmu.de/Publikationen/Papers/LoOP1649.pdf) by Kriegel et al. (2009). For the full API and additional documentation, see the [PyNomaly documentation](https://vc1492a.github.io/PyNomaly/).
 
 ## Dependencies
 - Python 3.8 - 3.13
@@ -176,6 +197,37 @@ the results for reach observation. Those observations which rank highly with var
 more than likely outliers. This is one potential approach of selecting the neighborhood size. Another is to
 select a value proportional to the number of observations, such an odd-valued integer close to the square root
 of the number of observations in your data (*sqrt(n_observations*).
+
+### Exceptions and Error Handling
+
+PyNomaly provides custom exceptions that can be caught and handled in your application code. All exceptions inherit from `PyNomalyError`:
+
+| Exception | Raised when |
+|---|---|
+| `PyNomalyError` | Base exception for all PyNomaly errors. |
+| `ValidationError` | Base class for input validation errors. |
+| `ClusterSizeError` | A cluster contains fewer observations than `n_neighbors`. |
+| `MissingValuesError` | Input data contains `NaN` values. |
+
+These exceptions are exported from the package and can be imported directly:
+
+```python
+from PyNomaly import loop
+from PyNomaly.loop import ClusterSizeError, MissingValuesError
+
+try:
+    m = loop.LocalOutlierProbability(data, n_neighbors=50, cluster_labels=labels).fit()
+except ClusterSizeError:
+    print("Reduce n_neighbors or use larger clusters.")
+except MissingValuesError:
+    print("Clean NaN values from your data before fitting.")
+```
+
+PyNomaly also issues `UserWarning` in non-fatal situations such as:
+- `n_neighbors` being zero or exceeding the number of observations (automatically adjusted)
+- `extent` not being 1, 2, or 3
+- Numba not being available when `use_numba=True` is set
+- `n_jobs > 1` without `use_numba=True` (falls back to sequential processing)
 
 ## Iris Data Example
 
@@ -448,13 +500,9 @@ and bug fixes can be represented by branches with the prefix `fix/` versus
 then be made from these branches into the repository's `dev` branch 
 prior to being pulled into `main`. 
 
-### Commit Messages and Releases
+### Commit Messages
 
-**Your commit messages are important** - here's why. 
-
-PyNomaly leverages [release-please](https://github.com/googleapis/release-please-action) to help automate the release process using the [Conventional Commits](https://www.conventionalcommits.org/) specification. When pull requests are opened to the `main` branch, release-please will collate the git commit messages and prepare an organized changelog and release notes. This process can be completed because of the Conventional Commits specification. 
-
-Conventional Commits provides an easy set of rules for creating an explicit commit history; which makes it easier to write automated tools on top of. This convention dovetails with SemVer, by describing the features, fixes, and breaking changes made in commit messages. You can check out examples [here](https://www.conventionalcommits.org/en/v1.0.0/#examples). Make a best effort to use the specification when contributing to Infactory code as it dramatically eases the documentation around releases and their features, breaking changes, bug fixes and documentation updates. 
+**Your commit messages are important.** PyNomaly uses the [Conventional Commits](https://www.conventionalcommits.org/) specification. Conventional Commits provides an easy set of rules for creating an explicit commit history, which dovetails with [Semantic Versioning](http://semver.org/) by describing the features, fixes, and breaking changes made in commit messages. You can check out examples [here](https://www.conventionalcommits.org/en/v1.0.0/#examples). Make a best effort to use the specification when contributing, as it dramatically eases the documentation around releases and their features, breaking changes, bug fixes, and documentation updates. 
 
 ### Tests
 When contributing, please ensure to run unit tests and add additional tests as 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ LoOP scores are computed through a pipeline of steps that transform raw distance
 For full mathematical detail, see the [original paper](http://www.dbs.ifi.lmu.de/Publikationen/Papers/LoOP1649.pdf) by Kriegel et al. (2009). For the full API and additional documentation, see the [PyNomaly documentation](https://vc1492a.github.io/PyNomaly/).
 
 ## Dependencies
-- Python 3.8 - 3.13
+- Python 3.8 - 3.14
 - numpy >= 1.16.3
 - python-utils >= 2.3.0
 - (optional) numba >= 0.45.1

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,110 @@
+# API Reference
+
+## `LocalOutlierProbability`
+
+```python
+from PyNomaly import loop
+
+clf = loop.LocalOutlierProbability(
+    data=None,
+    distance_matrix=None,
+    neighbor_matrix=None,
+    extent=3,
+    n_neighbors=10,
+    cluster_labels=None,
+    use_numba=False,
+    n_jobs=1,
+    progress_bar=False,
+)
+```
+
+### Constructor Parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `data` | `np.ndarray` or `pd.DataFrame` | `None` | Input data as a 2D array with shape (n_observations, n_features). Mutually exclusive with `distance_matrix`. |
+| `distance_matrix` | `np.ndarray` or `pd.DataFrame` | `None` | Pre-computed distance matrix with shape (n_observations, n_neighbors). Must be provided together with `neighbor_matrix`. Mutually exclusive with `data`. |
+| `neighbor_matrix` | `np.ndarray` or `pd.DataFrame` | `None` | Pre-computed neighbor index matrix with shape (n_observations, n_neighbors). Required when `distance_matrix` is provided. |
+| `extent` | `int` | `3` | Controls scoring sensitivity. Must be 1, 2, or 3. Corresponds to lambda times the standard deviation from the mean (1 = ~68%, 2 = ~95%, 3 = ~99.7%). |
+| `n_neighbors` | `int` | `10` | Number of nearest neighbors to consider. Must be greater than 0 and less than the number of observations. Automatically adjusted with a warning if invalid. |
+| `cluster_labels` | `list` | `None` | Cluster assignments for each observation. When provided, LoOP scores are computed within each cluster independently. |
+| `use_numba` | `bool` | `False` | Enable Numba JIT compilation for distance computation. Falls back to pure Python with a warning if Numba is not installed. |
+| `n_jobs` | `int` | `1` | Number of threads for parallel distance computation. Set to `-1` to use all CPU cores. Only effective when `use_numba=True`. |
+| `progress_bar` | `bool` | `False` | Display a progress bar during distance computation. |
+
+!!! note
+    Either `data` or both `distance_matrix` and `neighbor_matrix` must be provided, but not both `data` and `distance_matrix`.
+
+---
+
+### Methods
+
+#### `fit()`
+
+```python
+clf.fit() -> LocalOutlierProbability
+```
+
+Calculates the Local Outlier Probability for each observation in the input data.
+
+**Returns**: `self` -- the fitted model instance. Access scores via `clf.local_outlier_probabilities`.
+
+**Raises**:
+
+- `ClusterSizeError` -- if any cluster contains fewer observations than `n_neighbors`.
+- `MissingValuesError` -- if the input data contains `NaN` values.
+
+---
+
+#### `stream(x)`
+
+```python
+clf.stream(x) -> np.ndarray
+```
+
+Calculates the Local Outlier Probability for an individual observation against the fitted model. Must be called after `fit()`.
+
+**Parameters**:
+
+| Parameter | Type | Description |
+|---|---|---|
+| `x` | `np.ndarray` | A single observation to score. When using raw data mode, this should be a 1D array with the same number of features as the training data. When using distance matrix mode, this should be a scalar distance value. |
+
+**Returns**: `np.ndarray` -- the Local Outlier Probability of the input observation (a value in [0, 1]).
+
+!!! warning
+    The stream approach does **not** support clustered data. If `cluster_labels` were provided during `fit()`, PyNomaly will automatically refit using a single cluster and issue a `UserWarning`.
+
+---
+
+### Attributes
+
+Attributes available after calling `fit()`:
+
+| Attribute | Type | Description |
+|---|---|---|
+| `local_outlier_probabilities` | `np.ndarray` | Array of LoOP scores for each observation, with values in [0, 1]. |
+| `prob_distances` | `np.ndarray` | Probabilistic distances for each observation. |
+| `prob_distances_ev` | `np.ndarray` | Expected values of probabilistic distances for each observation's neighborhood. |
+| `norm_prob_local_outlier_factor` | `float` | Maximum normalized probabilistic local outlier factor across all observations. Used internally by `stream()`. |
+| `is_fit` | `bool` | Whether the model has been fit. |
+| `n_neighbors` | `int` | The number of neighbors used (may differ from the value passed to the constructor if it was adjusted). |
+
+---
+
+## Exceptions
+
+All exceptions are importable from `PyNomaly.loop` or directly from `PyNomaly`:
+
+```python
+from PyNomaly import ClusterSizeError, MissingValuesError
+# or
+from PyNomaly.loop import PyNomalyError, ValidationError, ClusterSizeError, MissingValuesError
+```
+
+| Exception | Parent | Description |
+|---|---|---|
+| `PyNomalyError` | `Exception` | Base exception for all PyNomaly errors. |
+| `ValidationError` | `PyNomalyError` | Base exception for input validation failures. |
+| `ClusterSizeError` | `ValidationError` | Raised when a cluster has fewer observations than `n_neighbors`. |
+| `MissingValuesError` | `ValidationError` | Raised when input data contains `NaN` values. |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,274 @@
+# Changelog
+
+All notable changes to PyNomaly will be documented in this Changelog.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) 
+and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## 0.4.0
+### Added
+- Parallel distance computation via Numba `prange` and the new `n_jobs` 
+parameter. Set `use_numba=True` with `n_jobs=-1` to use all available CPU 
+cores, providing 2-3x speedups on multi-core machines 
+([Issue #36](https://github.com/vc1492a/PyNomaly/issues/36)).
+- Optional `scipy` acceleration: uses `scipy.spatial.distance.cdist` for 
+distance computation and `scipy.special.erf` for the error function when 
+scipy is available, with graceful fallback to pure NumPy.
+- Dedicated Numba-specific tests (`test_numba_*`) that automatically run when 
+Numba is installed and are skipped otherwise, covering sequential equivalence, 
+parallel equivalence, single-cluster prange, and progress bar integration.
+### Changed
+- Replaced the O(n^2) Python nested loop for distance computation with a 
+vectorized NumPy implementation using chunked broadcasting. Progress bar 
+support is preserved via chunk-level updates.
+- Restructured the Numba JIT path from a generator-based approach (incompatible 
+with Numba's parallel mode) to non-generator kernels that support `numba.prange`.
+- Vectorized `_standard_distances`, `_prob_distances`, and 
+`_norm_prob_outlier_factor` pipeline methods, replacing Python `for` loops 
+with NumPy array operations.
+- The `n_jobs` parameter controls Numba thread-level parallelism via `prange`, 
+following the scikit-learn convention (`-1` for all cores, positive integer 
+for a fixed number of threads). Replaces the previous `num_threads` parameter 
+from the unreleased `feature/numba_parallel` branch. `n_jobs` only takes 
+effect when `use_numba=True`; without Numba a warning is issued and processing 
+falls back to the sequential vectorized path.
+
+## 0.3.5
+### Changed
+- Refactored the `Validate` class by dissolving it and moving validation methods 
+directly into `LocalOutlierProbability` as instance methods 
+([Issue #69](https://github.com/vc1492a/PyNomaly/issues/69)).
+- Renamed validation methods for clarity: `_fit()` → `_check_is_fit()`, 
+`_data()` → `_convert_to_array()`, `_inputs()` → `_validate_inputs()`, 
+`_cluster_size()` → `_check_cluster_size()`, `_n_neighbors()` → `_check_n_neighbors()`, 
+`_extent()` → `_check_extent()`, `_missing_values()` → `_check_missing_values()`, 
+`_no_cluster_labels()` → `_check_no_cluster_labels()`.
+- Replaced `sys.exit()` calls with proper exception handling. The library no longer 
+terminates the Python process on validation errors.
+### Added
+- Custom exception classes for better error handling: `PyNomalyError` (base), 
+`ValidationError`, `ClusterSizeError`, and `MissingValuesError`. These are now 
+exported from the package and can be caught by users.
+### Fixed
+- Fixed a compatibility issue with NumPy in Python 3.11+ where assigning an array 
+to a scalar position in `stream()` would raise a `ValueError` when using distance 
+matrix mode.
+
+## 0.3.4 
+### Changed 
+- Changed source code as necessary to address a [user-reported issue](https://github.com/vc1492a/PyNomaly/issues/49), corrected in [this commit](https://github.com/vc1492a/PyNomaly/commit/bbdd12a318316ca9c7e0272a5b06909f3fc4f9b0)
+
+## 0.3.3
+### Changed
+- The implementation of the progress bar to support use when the number of 
+observations is less than the width of the Python console in which the code 
+is being executed (tracked in [this issue](https://github.com/vc1492a/PyNomaly/issues/35)).
+### Added
+- Docstring to the testing functions to provide some additional documentation 
+of the testing (tracked in [this issue](https://github.com/vc1492a/PyNomaly/issues/41)).
+
+## 0.3.2
+### Changed
+- Removed numba as a strict dependency, which is now an optional dependency 
+that is not needed to use PyNomaly but which provides performance enhancements 
+when functions are called repeatedly, such as when the number of observations 
+is large. This relaxes the numba requirement introduced in version 0.3.0. 
+### Added
+- Added progress bar functionality that can be called using 
+`LocalOutlierProbability(progress_bar=True)` in both native 
+Python and numba just-in-time (JIT) compiled modes. 
+This is helpful in cases where PyNomaly is processing a large amount 
+of observations.  
+
+
+## 0.3.1
+### Changed
+- Removed Numba JIT compilation from the `_standard_distance` and 
+`_prob_distance` calculations. Using Numba JIT compilation there does 
+not result in a speed improvement and only add compilation overhead.
+- Integrated [pull request #33](https://github.com/vc1492a/PyNomaly/pull/33) 
+which decreases runtime about 30 to more than 90 percent in some cases, in 
+particular on repeated calls with larger datasets. 
+### Added
+- Type hinting for unit tests in `tests/test_loop.py`.
+
+## 0.3.0
+### Changed
+- The manner in which the standard distance is calculated from list 
+comprehension to a vectorized Numpy implementation, reducing compute 
+time for that specific calculation by approximately 75%. 
+- Removed formal testing and support for Python 3.4 
+([Python 3 adoption rates](https://rushter.com/blog/python-3-adoption/)).
+- Raised the minimum numpy version requirement from 1.12.0 to 1.16.3.
+### Added 
+- Numba just in time (JIT) compilation to improve the speed of some 
+of the core functionality, consistently achieving a further 20% reduction 
+in compute time when _n_ = 1000. Future optimizations could yield 
+further reductions in computation time. For now, requiring a strict numba version of `0.43.1` 
+in anticipation of [this deprecation](http://numba.pydata.org/numba-doc/latest/reference/deprecation.html#deprecation-of-reflection-for-list-and-set-types) - 
+which does not yet have an implemented solution. 
+
+## 0.2.7
+### Changed
+- Integrated various performance enhancements as described in 
+[pull request #30](https://github.com/vc1492a/PyNomaly/pull/30) that 
+increase PyNomaly's performance by at least up to 50% in some cases.
+- The Validate classes functions from public to private, as they are only 
+used in validating specification and data input into PyNomaly.
+### Added
+- [Issue #27](https://github.com/vc1492a/PyNomaly/issues/27) - Added 
+docstring to key functions in PyNomaly to ease future development and 
+provide additional information.
+- Additional unit tests to raise code coverage from 96% to 100%.
+
+## 0.2.6
+### Fixed
+- [Issue #25](https://github.com/vc1492a/PyNomaly/issues/25) - Fixed an issue
+that caused zero division errors when all the values in a neighborhood are
+duplicate samples.
+### Changed
+- The error behavior when attempting to use the stream approach
+before calling `fit`. While the previous implementation resulted in a
+warning and system exit, PyNomaly now attempts to `fit` (assumes data or a
+distance matrix is available) and then later calls `stream`. If no
+data or distance matrix is provided, a warning is raised.
+### Added
+- [Issue #24](https://github.com/vc1492a/PyNomaly/issues/24) - Added
+the ability to use one's own distance matrix,
+provided a neighbor index matrix is also provided. This ensures
+PyNomaly can be used with distances other than the euclidean.
+See the file `iris_dist_grid.py` for examples.
+- [Issue #23](https://github.com/vc1492a/PyNomaly/issues/23) - Added
+Python 3.7 to the tested distributions in Travis CI and passed tests.
+- Unit tests to monitor the issues and features covered
+in issues [24](https://github.com/vc1492a/PyNomaly/issues/24) and
+[25](https://github.com/vc1492a/PyNomaly/issues/25).
+
+
+## 0.2.5
+### Fixed
+- [Issue #20](https://github.com/vc1492a/PyNomaly/issues/20) - Fixed
+a bug that inadvertently used global means of the probabilistic distance
+as the expected value of the probabilistic distance, as opposed to the
+expected value of the probabilistic distance within a neighborhood of
+a point.
+- Integrated [pull request #21](https://github.com/vc1492a/PyNomaly/pull/21) -
+This pull request addressed the issue noted above.
+### Changed
+- Changed the default behavior to strictly not supporting the
+use of missing values in the input data, as opposed to the soft enforcement
+(a simple user warning) used in the previous behavior.
+
+## 0.2.4
+### Fixed
+- [Issue #17](https://github.com/vc1492a/PyNomaly/issues/17) - Fixed
+a bug that allowed for a column of empty values in the primary data store.
+- Integrated [pull request #18](https://github.com/vc1492a/PyNomaly/pull/18) -
+Fixed a bug that was not causing dependencies such as numpy to skip
+installation when installing PyNomaly via pip.
+
+## 0.2.3
+### Fixed
+- [Issue #14](https://github.com/vc1492a/PyNomaly/issues/14) - Fixed an issue
+that was causing a ZeroDivisionError when the specified neighborhood size
+is larger than the total number of observations in the smallest cluster.
+
+## 0.2.2
+### Changed
+- This implementation to align more closely with the specification of the
+approach in the original paper. The extent parameter now takes an integer
+value of 1, 2, or 3 that corresponds to the lambda parameter specified
+in the paper. See the [readme](https://github.com/vc1492a/PyNomaly/blob/master/readme.md) for more details.
+- Refactored the code base and created the Validate class, which includes
+checks for data type, correct specification, and other dependencies.
+### Added
+- Automated tests to ensure the desired functionality is being met can now be
+found in the `PyNomaly/tests` directory.
+- Code for the examples in the readme can now be found in the `examples` directory.
+- Additional information for parameter selection in the [readme](https://github.com/vc1492a/PyNomaly/blob/master/readme.md).
+
+## 0.2.1
+### Fixed
+- [Issue #10](https://github.com/vc1492a/PyNomaly/issues/10) - Fixed error on line
+142 which was causing the class to fail. More explicit examples
+were also included in the readme for using numpy arrays.
+
+### Added
+- An improvement to the Euclidean distance calculation by [MichaelSchreier](https://github.com/MichaelSchreier)
+which brings a over a 50% reduction in computation time.
+
+## 0.2.0
+### Added
+- Added new functionality to PyNomaly by integrating a modified LoOP
+approach introduced by Hamlet et al. which can be used for streaming
+data applications or in the case where computational expense is a concern.
+Data is first fit to a "training set", with any additional observations
+considered for outlierness against this initial set.
+
+## 0.1.8
+### Fixed
+- Fixed an issue which allowed the number of neighbors considered to exceed the number of observations. Added a check
+to ensure this is no longer possible.
+
+## 0.1.7
+### Fixed
+- Fixed an issue inadvertently introduced in 0.1.6 that caused distance calculations to be incorrect, 
+thus resulting in incorrect LoOP values.  
+
+## 0.1.6
+### Fixed
+- Updated the distance calculation such that the euclidean distance calculation has been separated from 
+the main distance calculation function.
+- Fixed an error in the calculation of the standard distance. 
+
+### Changed
+- .fit() now returns a fitted object instead of local_outlier_probabilities. Local outlier probabilities can 
+be now be retrieved by calling .local_outlier_probabilities. See the readme for an example. 
+- Some private functions have been renamed. 
+
+## 0.1.5
+### Fixed
+- [Issue #4](https://github.com/vc1492a/PyNomaly/issues/4) - Separated parameter type checks 
+from checks for invalid parameter values.
+    - @accepts decorator verifies LocalOutlierProbability parameters are of correct type.
+    - Parameter value checks moved from .fit() to init.
+- Fixed parameter check to ensure extent value is in the range (0., 1.] instead of [0, 1] (extent cannot be zero). 
+- [Issue #1](https://github.com/vc1492a/PyNomaly/issues/1) -  Added type check using @accepts decorator for cluster_labels.    
+
+## 0.1.4
+### Fixed
+- [Issue #3](https://github.com/vc1492a/PyNomaly/issues/3) - .fit() fails if the sum of squared distances sums to 0.
+    - Added check to ensure the sum of square distances is greater than zero.
+    - Added UserWarning to increase the neighborhood size if all neighbors in n_neighbors are 
+    zero distance from an observation. 
+- Added UserWarning to check for integer type n_neighbor conditions versus float type.
+- Changed calculation of the probabilistic local outlier factor expected value to Numpy operation
+    from base Python. 
+    
+## 0.1.3
+### Fixed
+- Altered the distance matrix computation to return a triangular matrix instead of a 
+fully populated matrix. This was made to ensure no duplicate neighbors were present 
+in computing the neighborhood distance for each observation. 
+
+## 0.1.2
+### Added
+- LICENSE.txt file of Apache License, Version 2.0.
+- setup.py, setup.cfg files configured for release to PyPi.
+- Changed name throughout code base from PyLoOP to PyNomaly.
+
+### Other
+- Initial release to PyPi.
+
+## 0.1.1
+### Other
+- A bad push to PyPi necessitated the need to skip a version number. 
+    - Chosen name of PyLoOP not present on test index but present on production PyPi index. 
+    - Issue not known until push was made to the test index.
+    - Skipped version number to align test and production PyPi indices.
+
+## 0.1.0 - 2017-05-19
+### Added
+- readme.md file documenting methodology, package dependencies, use cases, 
+how to contribute, and acknowledgements.
+- Initial open release of PyNomaly codebase on Github. 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,27 @@
+# Contributing
+
+Please use the [issue tracker](https://github.com/vc1492a/PyNomaly/issues) to report any erroneous behavior or desired feature requests.
+
+If you would like to contribute to development, please fork the repository and make any changes to a branch which corresponds to an open issue. Hot fixes and bug fixes can be represented by branches with the prefix `fix/` versus `feature/` for new capabilities or code improvements. Pull requests will then be made from these branches into the repository's `dev` branch prior to being pulled into `main`.
+
+## Commit Messages
+
+**Your commit messages are important.** PyNomaly uses the [Conventional Commits](https://www.conventionalcommits.org/) specification. Conventional Commits provides an easy set of rules for creating an explicit commit history, which dovetails with [Semantic Versioning](http://semver.org/) by describing the features, fixes, and breaking changes made in commit messages. You can check out examples [here](https://www.conventionalcommits.org/en/v1.0.0/#examples). Make a best effort to use the specification when contributing, as it dramatically eases the documentation around releases and their features, breaking changes, bug fixes, and documentation updates.
+
+## Tests
+
+When contributing, please ensure to run unit tests and add additional tests as necessary if adding new functionality. To run the unit tests, use `pytest`:
+
+```shell
+python3 -m pytest --cov=PyNomaly -s -v
+```
+
+To run the tests with Numba enabled, simply set the flag `NUMBA` in `test_loop.py` to `True`. Note that a drop in coverage is expected due to portions of the code being compiled upon code execution. Additionally, there are dedicated Numba-specific tests (`test_numba_*`) that run automatically when Numba is installed and are skipped otherwise.
+
+## Versioning
+
+[Semantic versioning](http://semver.org/) is used for this project. If contributing, please conform to semantic versioning guidelines when submitting a pull request.
+
+## License
+
+This project is licensed under the Apache 2.0 license.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,107 @@
+# Examples
+
+## Iris Data Example
+
+We'll be using the well-known Iris dataset to show LoOP's capabilities. You'll need:
+
+- matplotlib 2.0.0 or greater
+- PyDataset 0.2.0 or greater
+- scikit-learn 0.18.1 or greater
+
+First, let's import the packages and libraries we will need.
+
+```python
+from PyNomaly import loop
+import pandas as pd
+from pydataset import data
+import numpy as np
+from sklearn.cluster import DBSCAN
+import matplotlib.pyplot as plt
+from mpl_toolkits.mplot3d import Axes3D
+```
+
+Create two sets of Iris data for scoring; one with clustering and the other without.
+
+```python
+iris = pd.DataFrame(data('iris').drop(columns=['Species']))
+```
+
+Cluster the data using DBSCAN and generate two sets of scores. In both cases, we will use the default values for both `extent` (3) and `n_neighbors` (10).
+
+```python
+db = DBSCAN(eps=0.9, min_samples=10).fit(iris)
+m = loop.LocalOutlierProbability(iris).fit()
+scores_noclust = m.local_outlier_probabilities
+m_clust = loop.LocalOutlierProbability(iris, cluster_labels=list(db.labels_)).fit()
+scores_clust = m_clust.local_outlier_probabilities
+```
+
+Organize the data into two separate Pandas DataFrames.
+
+```python
+iris_clust = pd.DataFrame(iris.copy())
+iris_clust['scores'] = scores_clust
+iris_clust['labels'] = db.labels_
+iris['scores'] = scores_noclust
+```
+
+Visualize the scores provided by LoOP in both cases (with and without clustering).
+
+```python
+fig = plt.figure(figsize=(7, 7))
+ax = fig.add_subplot(111, projection='3d')
+ax.scatter(iris['Sepal.Width'], iris['Petal.Width'], iris['Sepal.Length'],
+c=iris['scores'], cmap='seismic', s=50)
+ax.set_xlabel('Sepal.Width')
+ax.set_ylabel('Petal.Width')
+ax.set_zlabel('Sepal.Length')
+plt.show()
+```
+
+**LoOP Scores without Clustering**
+
+![LoOP Scores without Clustering](https://github.com/vc1492a/PyNomaly/blob/main/images/scores.png?raw=true)
+
+**LoOP Scores with Clustering**
+
+![LoOP Scores with Clustering](https://github.com/vc1492a/PyNomaly/blob/main/images/scores_clust.png?raw=true)
+
+**DBSCAN Cluster Assignments**
+
+![DBSCAN Cluster Assignments](https://github.com/vc1492a/PyNomaly/blob/main/images/cluster_assignments.png?raw=true)
+
+Note the differences between using `LocalOutlierProbability` with and without clustering. In the example without clustering, samples are scored according to the distribution of the entire data set. In the example with clustering, each sample is scored according to the distribution of each cluster. Which approach is suitable depends on the use case.
+
+!!! note
+    Data was not normalized in this example, but it's probably a good idea to do so in practice.
+
+## Distance Metric Comparison
+
+The example in `examples/iris_dist_grid.py` demonstrates scoring with several different distance metrics by providing custom distance and neighbor matrices:
+
+**LoOP Scores by Distance Metric**
+
+![LoOP Scores by Distance Metric](https://github.com/vc1492a/PyNomaly/blob/main/images/scores_by_distance_metric.png?raw=true)
+
+## Streaming Data
+
+The example in `examples/stream.py` demonstrates the streaming approach using the Iris dataset. See the [User Guide](user-guide.md#streaming-data) for a complete walkthrough.
+
+**LoOP Scores using Stream Approach with n=10**
+
+![LoOP Scores using Stream Approach](https://github.com/vc1492a/PyNomaly/blob/main/images/scores_stream.png?raw=true)
+
+## Additional Examples
+
+The following example scripts are available in the [`examples/`](https://github.com/vc1492a/PyNomaly/tree/main/examples) directory of the repository:
+
+| Script | Description |
+|---|---|
+| `iris.py` | Iris dataset with and without clustering |
+| `iris_dist_grid.py` | Comparing multiple distance metrics |
+| `stream.py` | Streaming data approach |
+| `numba_speed_diff.py` | Numba vs. pure Python speed comparison |
+| `parallel_benchmark.py` | Parallel processing benchmarks with `n_jobs` |
+| `multiple_gaussian_2d.py` | 2D Gaussian mixture data |
+| `1d_time_series.py` | 1-dimensional time series anomaly detection |
+| `cluster_labels_flipped.py` | Flipped cluster labels consistency check |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,7 +2,7 @@
 
 ## Dependencies
 
-- Python 3.8 - 3.13
+- Python 3.8 - 3.14
 - numpy >= 1.16.3
 - python-utils >= 2.3.0
 - (optional) numba >= 0.45.1

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,70 @@
+# Getting Started
+
+## Dependencies
+
+- Python 3.8 - 3.13
+- numpy >= 1.16.3
+- python-utils >= 2.3.0
+- (optional) numba >= 0.45.1
+- (optional) scipy >= 1.3.0
+
+Numba just-in-time (JIT) compiles the function which calculates the Euclidean
+distance between observations, providing a reduction in computation time
+(significantly when a large number of observations are scored). Numba is not a
+requirement and PyNomaly may still be used solely with numpy if desired.
+
+When scipy is available, PyNomaly uses its optimized distance
+computation (`scipy.spatial.distance.cdist`) and error function (`scipy.special.erf`)
+implementations for additional performance gains.
+
+## Installation
+
+Install from the Python Package Index:
+
+```shell
+pip install PyNomaly
+```
+
+Or from conda-forge:
+
+```shell
+conda install conda-forge::pynomaly
+```
+
+## Quick Start
+
+```python
+from PyNomaly import loop
+m = loop.LocalOutlierProbability(data).fit()
+scores = m.local_outlier_probabilities
+print(scores)
+```
+
+where `data` is a NxM (N rows, M columns; 2-dimensional) set of data as either a Pandas DataFrame or Numpy array.
+
+`LocalOutlierProbability` sets the `extent` (an integer value of 1, 2, or 3) and `n_neighbors` (must be greater than 0) parameters with the default values of 3 and 10, respectively:
+
+```python
+from PyNomaly import loop
+m = loop.LocalOutlierProbability(data, extent=2, n_neighbors=20).fit()
+scores = m.local_outlier_probabilities
+print(scores)
+```
+
+## Using Cluster Labels
+
+This implementation of LoOP includes an optional `cluster_labels` parameter. This is useful in cases where regions of varying density occur within the same set of data. When using `cluster_labels`, the Local Outlier Probability of a sample is calculated with respect to its cluster assignment.
+
+```python
+from PyNomaly import loop
+from sklearn.cluster import DBSCAN
+db = DBSCAN(eps=0.6, min_samples=50).fit(data)
+m = loop.LocalOutlierProbability(
+    data, extent=2, n_neighbors=20, cluster_labels=list(db.labels_)
+).fit()
+scores = m.local_outlier_probabilities
+print(scores)
+```
+
+!!! note
+    Unless your data is all the same scale, it may be a good idea to normalize your data with z-scores or another normalization scheme prior to using LoOP, especially when working with multiple dimensions of varying scale. Users must also appropriately handle missing values prior to using LoOP, as LoOP does not support Pandas DataFrames or Numpy arrays with missing values.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,0 +1,91 @@
+# How It Works
+
+This page explains the LoOP (Local Outlier Probabilities) algorithm as implemented in PyNomaly. For full mathematical detail, see the [original paper](http://www.dbs.ifi.lmu.de/Publikationen/Papers/LoOP1649.pdf) by Kriegel, Kröger, Schubert, and Zimek (2009).
+
+## Algorithm Pipeline
+
+LoOP scores are computed through a pipeline of steps that transform raw distances into a probability in the range [0, 1].
+
+### 1. Nearest Neighbor Distances
+
+For each observation, the distances to its *k* nearest neighbors are computed using Euclidean distance. If cluster labels are provided, neighbors are found only within the same cluster, so that each observation is scored relative to its own local region of data.
+
+When a custom distance matrix is provided, this step is skipped and the user-supplied distances are used directly.
+
+### 2. Standard Distance
+
+The **standard distance** of an observation is the root mean square of its *k* nearest neighbor distances:
+
+```
+standard_distance(o) = sqrt( (1/k) * sum(dist(o, neighbor_i)^2) )
+```
+
+This captures, on average, how far away an observation's neighbors are. Points in dense regions will have small standard distances; points in sparse regions will have large ones.
+
+### 3. Probabilistic Distance
+
+The **probabilistic distance** scales the standard distance by the `extent` parameter (lambda):
+
+```
+pdist(o) = extent * standard_distance(o)
+```
+
+The `extent` parameter corresponds to the statistical notion of an outlier deviating more than lambda standard deviations from the mean:
+
+| `extent` | Statistical meaning | Approximate coverage |
+|---|---|---|
+| 1 | 1 standard deviation | ~68% |
+| 2 | 2 standard deviations | ~95% |
+| 3 | 3 standard deviations | ~99.7% |
+
+A higher extent makes scoring more conservative (fewer points flagged as outliers).
+
+### 4. Probabilistic Local Outlier Factor (PLOF)
+
+The **PLOF** compares an observation's probabilistic distance to the expected (mean) probabilistic distance of its neighbors:
+
+```
+PLOF(o) = pdist(o) / E[pdist(neighbors(o))] - 1
+```
+
+- A PLOF near **zero** means the observation's local density is similar to its neighbors.
+- A **large positive** PLOF means the observation sits in a sparser region relative to its neighbors, suggesting it may be an outlier.
+
+### 5. Normalized PLOF (nPLOF)
+
+The **nPLOF** is a normalization constant that accounts for the overall variability of PLOF values within a cluster:
+
+```
+nPLOF = extent * sqrt( E[PLOF^2] )
+```
+
+where the expectation is taken over all observations in the same cluster. This ensures that the final LoOP scores are comparable across clusters with different density characteristics.
+
+### 6. Local Outlier Probability (LoOP)
+
+The final **LoOP score** applies the Gaussian error function to produce a value in [0, 1]:
+
+```
+LoOP(o) = max(0, erf( PLOF(o) / (nPLOF * sqrt(2)) ))
+```
+
+The error function maps the normalized PLOF ratio onto a probability scale:
+
+- **LoOP = 0**: The observation is consistent with its neighborhood density.
+- **LoOP close to 1**: The observation is very likely an outlier relative to its local neighborhood.
+
+Because scores are true probabilities, practitioners can apply thresholds according to their application requirements without needing to interpret arbitrary score magnitudes.
+
+## Clustering
+
+When `cluster_labels` are provided, each of the above steps is computed *within* each cluster independently. This is important when the data contains regions of naturally varying density -- without clustering, points in a globally sparse but locally dense region might be incorrectly flagged as outliers.
+
+## Streaming
+
+PyNomaly also supports a streaming mode based on Hamlet et al.'s modifications to the original LoOP approach. In streaming mode:
+
+1. The standard LoOP algorithm is first `fit()` on a training dataset.
+2. Key statistics from the fit (expected probabilistic distances, normalized PLOF) are stored.
+3. New observations are scored individually via `stream()` using these stored statistics, without refitting the entire model.
+
+This trades some accuracy for computational efficiency, making it suitable for applications where data arrives incrementally. See the [User Guide](user-guide.md#streaming-data) for details.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,81 @@
+# PyNomaly
+
+PyNomaly is a Python 3 implementation of LoOP (Local Outlier Probabilities).
+LoOP is a local density based outlier detection method by Kriegel, Kröger, Schubert, and Zimek which provides outlier
+scores in the range of [0,1] that are directly interpretable as the probability of a sample being an outlier.
+
+PyNomaly is a core library of [deepchecks](https://github.com/deepchecks/deepchecks), [OmniDocBench](https://github.com/opendatalab/OmniDocBench) and [pysad](https://github.com/selimfirat/pysad).
+
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![PyPi](https://img.shields.io/badge/pypi-0.4.0-blue.svg)](https://pypi.python.org/pypi/PyNomaly/0.4.0)
+[![Total Downloads](https://static.pepy.tech/badge/pynomaly)](https://pepy.tech/projects/pynomaly)
+[![Monthly Downloads](https://static.pepy.tech/badge/pynomaly/month)](https://pepy.tech/projects/pynomaly)
+![Tests](https://github.com/vc1492a/PyNomaly/actions/workflows/tests.yml/badge.svg)
+[![Coverage Status](https://coveralls.io/repos/github/vc1492a/PyNomaly/badge.svg?branch=main)](https://coveralls.io/github/vc1492a/PyNomaly?branch=main)
+[![JOSS](http://joss.theoj.org/papers/f4d2cfe680768526da7c1f6a2c103266/status.svg)](http://joss.theoj.org/papers/f4d2cfe680768526da7c1f6a2c103266)
+
+## Overview
+
+The outlier score of each sample is called the Local Outlier Probability.
+It measures the local deviation of density of a given sample with
+respect to its neighbors as Local Outlier Factor (LOF), but provides normalized
+outlier scores in the range [0,1]. These outlier scores are directly interpretable
+as a probability of an object being an outlier. Since Local Outlier Probabilities provides scores in the
+range [0,1], practitioners are free to interpret the results according to the application.
+
+Like LOF, it is local in that the anomaly score depends on how isolated the sample is
+with respect to the surrounding neighborhood. Locality is given by k-nearest neighbors,
+whose distance is used to estimate the local density. By comparing the local density of a sample to the
+local densities of its neighbors, one can identify samples that lie in regions of lower
+density compared to their neighbors and thus identify samples that may be outliers according to their Local
+Outlier Probability.
+
+The authors' 2009 paper detailing LoOP's theory, formulation, and application is provided by
+Ludwig-Maximilians University Munich - Institute for Informatics;
+[LoOP: Local Outlier Probabilities](http://www.dbs.ifi.lmu.de/Publikationen/Papers/LoOP1649.pdf).
+
+## Quick Links
+
+- [How It Works](how-it-works.md) -- understand the algorithm
+- [Getting Started](getting-started.md) -- installation and first steps
+- [User Guide](user-guide.md) -- parameters, performance, streaming, and error handling
+- [API Reference](api.md) -- full class and method documentation
+- [Examples](examples.md) -- worked examples with visualizations
+
+## Research
+
+If citing PyNomaly, use the following:
+
+```bibtex
+@article{Constantinou2018,
+  doi = {10.21105/joss.00845},
+  url = {https://doi.org/10.21105/joss.00845},
+  year  = {2018},
+  month = {oct},
+  publisher = {The Open Journal},
+  volume = {3},
+  number = {30},
+  pages = {845},
+  author = {Valentino Constantinou},
+  title = {{PyNomaly}: Anomaly detection using Local Outlier Probabilities ({LoOP}).},
+  journal = {Journal of Open Source Software}
+}
+```
+
+## References
+
+1. Breunig M., Kriegel H.-P., Ng R., Sander, J. LOF: Identifying Density-based Local Outliers. ACM SIGMOD International Conference on Management of Data (2000). [PDF](http://www.dbs.ifi.lmu.de/Publikationen/Papers/LOF.pdf).
+2. Kriegel H., Kröger P., Schubert E., Zimek A. LoOP: Local Outlier Probabilities. 18th ACM conference on Information and knowledge management, CIKM (2009). [PDF](http://www.dbs.ifi.lmu.de/Publikationen/Papers/LoOP1649.pdf).
+3. Goldstein M., Uchida S. A Comparative Evaluation of Unsupervised Anomaly Detection Algorithms for Multivariate Data. PLoS ONE 11(4): e0152173 (2016).
+4. Hamlet C., Straub J., Russell M., Kerlin S. An incremental and approximate local outlier probability algorithm for intrusion detection and its evaluation. Journal of Cyber Security Technology (2016). [DOI](http://www.tandfonline.com/doi/abs/10.1080/23742917.2016.1226651?journalCode=tsec20).
+
+## Acknowledgements
+
+- The authors of LoOP (Local Outlier Probabilities)
+    - Hans-Peter Kriegel
+    - Peer Kröger
+    - Erich Schubert
+    - Arthur Zimek
+- [NASA Jet Propulsion Laboratory](https://jpl.nasa.gov/)
+    - [Kyle Hundman](https://github.com/khundman)
+    - [Ian Colwell](https://github.com/iancolwell)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,210 @@
+# User Guide
+
+## Choosing Parameters
+
+### extent
+
+The `extent` parameter controls the sensitivity of the scoring in practice. The parameter corresponds to the statistical notion of an outlier defined as an object deviating more than a given lambda (`extent`) times the standard deviation from the mean.
+
+| `extent` | Meaning | Empirical rule |
+|---|---|---|
+| 1 | 1 standard deviation | ~68% |
+| 2 | 2 standard deviations | ~95% |
+| 3 | 3 standard deviations | ~99.7% |
+
+A value of 2 implies outliers deviating more than 2 standard deviations from the mean. The appropriate parameter should be selected according to the level of sensitivity needed for the input data and application.
+
+### n_neighbors
+
+The `n_neighbors` parameter defines the number of neighbors to consider about each sample (neighborhood size) when determining its Local Outlier Probability.
+
+The ideal number of neighbors is dependent on the input data. However, the notion of an outlier implies it would be considered as such regardless of the number of neighbors considered. Some approaches for selecting this parameter:
+
+- Use several different neighborhood sizes and average the results for each observation. Those observations which rank highly across varying neighborhood sizes are likely outliers.
+- Select a value proportional to the number of observations, such as an odd-valued integer close to `sqrt(n_observations)`.
+
+## Speeding Things Up with Numba
+
+For large datasets, Numba's just-in-time (JIT) compilation can significantly speed up distance computation. Enable it with `use_numba=True`:
+
+```python
+from PyNomaly import loop
+m = loop.LocalOutlierProbability(data, extent=2, n_neighbors=20, use_numba=True).fit()
+scores = m.local_outlier_probabilities
+print(scores)
+```
+
+To go further, set `n_jobs=-1` to enable Numba's thread-level parallelism (`prange`), which distributes work across all available CPU cores:
+
+```python
+from PyNomaly import loop
+m = loop.LocalOutlierProbability(
+    data, extent=2, n_neighbors=20,
+    use_numba=True, n_jobs=-1
+).fit()
+scores = m.local_outlier_probabilities
+print(scores)
+```
+
+This provides **2-3x speedups** on multi-core machines (benchmarked on 8 cores). The parallelism works within each cluster's distance computation, so it benefits both single-cluster and multi-cluster data.
+
+- Set `n_jobs=-1` to use all cores, or specify a positive integer for a fixed number of threads.
+- The default `n_jobs=1` runs sequentially.
+- `n_jobs` only takes effect when `use_numba=True`. If `n_jobs > 1` is set without Numba, PyNomaly will warn and fall back to the sequential vectorized path.
+- Parallel processing is only applicable when raw input data is provided -- if a pre-existing distance matrix is provided, the distance computation step is skipped entirely.
+
+Numba must be installed to use JIT compilation. PyNomaly has been tested with Numba versions 0.45.1 through 0.65.1.
+
+## Progress Bars
+
+You may choose to print progress bars _with or without_ the use of Numba by passing `progress_bar=True` to `LocalOutlierProbability()`:
+
+```python
+from PyNomaly import loop
+m = loop.LocalOutlierProbability(data, use_numba=True, n_jobs=-1, progress_bar=True).fit()
+```
+
+Progress bars are supported in both sequential and Numba execution modes.
+
+## Using Numpy Arrays
+
+When using numpy, make sure to use 2-dimensional arrays in tabular format:
+
+```python
+import numpy as np
+from PyNomaly import loop
+
+data = np.array([
+    [43.3, 30.2, 90.2],
+    [62.9, 58.3, 49.3],
+    [55.2, 56.2, 134.2],
+    [48.6, 80.3, 50.3],
+    [67.1, 60.0, 55.9],
+    [421.5, 90.3, 50.0]
+])
+
+scores = loop.LocalOutlierProbability(data, n_neighbors=3).fit().local_outlier_probabilities
+print(scores)
+```
+
+The shape of the input array corresponds to rows (observations) and columns (features):
+
+```python
+print(data.shape)
+# (6, 3)
+```
+
+## Specifying a Distance Matrix
+
+PyNomaly provides the ability to specify a distance matrix so that any distance metric can be used (a neighbor index matrix must also be provided). This can be useful when wanting to use a distance other than the Euclidean.
+
+!!! note
+    In order to maintain alignment with the LoOP definition of closest neighbors, an additional neighbor is added when using [scikit-learn's NearestNeighbors](https://scikit-learn.org/1.5/modules/neighbors.html) since `NearestNeighbors` includes the point itself when calculating the closest neighbors (whereas the LoOP method does not include distances to point itself).
+
+```python
+import numpy as np
+from sklearn.neighbors import NearestNeighbors
+
+data = np.array([
+    [43.3, 30.2, 90.2],
+    [62.9, 58.3, 49.3],
+    [55.2, 56.2, 134.2],
+    [48.6, 80.3, 50.3],
+    [67.1, 60.0, 55.9],
+    [421.5, 90.3, 50.0]
+])
+
+n_neighbors = 3
+neigh = NearestNeighbors(n_neighbors=n_neighbors+1, metric='hamming')
+neigh.fit(data)
+d, idx = neigh.kneighbors(data, return_distance=True)
+
+# Remove self-distances
+indices = np.delete(indices, 0, 1)
+distances = np.delete(distances, 0, 1)
+
+m = loop.LocalOutlierProbability(
+    distance_matrix=d, neighbor_matrix=idx, n_neighbors=n_neighbors+1
+).fit()
+scores = m.local_outlier_probabilities
+```
+
+## Streaming Data
+
+PyNomaly contains an implementation of Hamlet et al.'s modifications to the original LoOP approach, which may be used for applications involving streaming data or where rapid calculations may be necessary.
+
+First, the standard LoOP algorithm is used on "training" data, with certain attributes of the fitted data stored from the original LoOP approach. Then, as new points are considered, these fitted attributes are called when calculating the score of the incoming streaming data due to the use of averages from the initial fit, such as the use of a global value for the expected value of the probabilistic distance.
+
+Despite the potential for increased error when compared to the standard approach, it may be effective in streaming applications where refitting the standard approach over all points could be computationally expensive.
+
+### Example
+
+Using the Iris dataset, taking the first 120 observations as training data and the remaining 30 as a stream:
+
+```python
+iris = iris.sample(frac=1)  # shuffle data
+iris_train = iris.iloc[:, 0:4].head(120)
+iris_test = iris.iloc[:, 0:4].tail(30)
+```
+
+Fit the model on training data:
+
+```python
+m_train = loop.LocalOutlierProbability(iris_train, n_neighbors=10)
+m_train.fit()
+iris_train_scores = m_train.local_outlier_probabilities
+```
+
+Score streaming observations individually:
+
+```python
+iris_test_scores = []
+for index, row in iris_test.iterrows():
+    array = np.array([
+        row['Sepal.Length'], row['Sepal.Width'],
+        row['Petal.Length'], row['Petal.Width']
+    ])
+    iris_test_scores.append(m_train.stream(array))
+iris_test_scores = np.array(iris_test_scores)
+```
+
+### Notes
+
+- When calculating the LoOP score of incoming data, the original fitted scores are **not** updated.
+- In some applications, it may be beneficial to refit the data periodically.
+- The stream functionality assumes that either data or a distance matrix (or value) will be used across both fitting and streaming, with no changes in specification between steps.
+- The stream approach does **not** support clustered data. If cluster labels were used during `fit()`, PyNomaly will automatically refit using a single cluster of points when `stream()` is called.
+
+## Exceptions and Error Handling
+
+PyNomaly provides custom exceptions that can be caught and handled in your application code. All exceptions inherit from `PyNomalyError`:
+
+| Exception | Raised when |
+|---|---|
+| `PyNomalyError` | Base exception for all PyNomaly errors. |
+| `ValidationError` | Base class for input validation errors. |
+| `ClusterSizeError` | A cluster contains fewer observations than `n_neighbors`. |
+| `MissingValuesError` | Input data contains `NaN` values. |
+
+These exceptions are exported from the package and can be imported directly:
+
+```python
+from PyNomaly import loop
+from PyNomaly.loop import ClusterSizeError, MissingValuesError
+
+try:
+    m = loop.LocalOutlierProbability(
+        data, n_neighbors=50, cluster_labels=labels
+    ).fit()
+except ClusterSizeError:
+    print("Reduce n_neighbors or use larger clusters.")
+except MissingValuesError:
+    print("Clean NaN values from your data before fitting.")
+```
+
+PyNomaly also issues `UserWarning` in non-fatal situations such as:
+
+- `n_neighbors` being zero or exceeding the number of observations (automatically adjusted)
+- `extent` not being 1, 2, or 3
+- Numba not being available when `use_numba=True` is set
+- `n_jobs > 1` without `use_numba=True` (falls back to sequential processing)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,47 @@
+site_name: PyNomaly
+site_url: https://vc1492a.github.io/PyNomaly/
+site_description: >-
+  PyNomaly - A Python 3 implementation of LoOP (Local Outlier Probabilities),
+  a local density based outlier detection method providing outlier scores in [0, 1].
+repo_url: https://github.com/vc1492a/PyNomaly
+repo_name: vc1492a/PyNomaly
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: white
+      accent: grey
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: black
+      accent: grey
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.sections
+    - navigation.top
+    - content.code.copy
+
+markdown_extensions:
+  - admonition
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
+  - pymdownx.details
+  - tables
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - How It Works: how-it-works.md
+  - Getting Started: getting-started.md
+  - User Guide: user-guide.md
+  - Examples: examples.md
+  - API Reference: api.md
+  - Contributing: contributing.md
+  - Changelog: changelog.md


### PR DESCRIPTION
## Summary

- Adds a full MkDocs documentation site (Material theme, monochrome) with pages for: algorithm explanation, getting started, user guide, examples, API reference, contributing, and changelog
- Expands the README with two new sections: "How It Works" (LoOP algorithm pipeline) and "Exceptions and Error Handling" (custom exception hierarchy)
- Adds a documentation badge and links to the hosted docs in the README
- Updates commit message guidelines to remove release-please references
- Adds a GitHub Actions workflow (`.github/workflows/docs.yml`) that deploys docs to GitHub Pages on push to `main`

## Before merging

- [x] Preview docs locally with `mkdocs serve`
- [x] Set GitHub Pages source to `gh-pages` / `/ (root)` in repo settings
- [x] Review all docs pages for accuracy

Closes #34

Made with [Cursor](https://cursor.com)